### PR TITLE
Fix for bot not playing initial move as white

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -60,7 +60,7 @@ class Game {
   }
 
   playingAs(event) {
-    return (event.white.id === this.name) ? "white" : "black";
+    return (event.name.id === this.name) ? "white" : "black";
   }
 
   isTurn(colour, moves) {


### PR DESCRIPTION
Hi there,

I noticed that the bot worked fine when I played as white (bot as black) but it didn't work when I played as black (bot as white).

I narrowed down the issue to the bot not recognising that it currently is its own turn, which was caused by the `playingAs `method in `Game.js` returning the wrong colour. I found the reason it does so is because the Lichess API returns `event.white.id` as lowercase, e.g. "mybot" but if `this.name` is "MyBot" then `event.white.id === this.name` evaluates to `false`. Thus, using `event.white.name` (which is not made lowercase) instead of `event.white.id` fixes the issue.