### PR TITLE
Correct API Endpoint for Bot Upgrade and Fix Broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bot-o-tron
 [![Build Status](https://travis-ci.org/tailuge/bot-o-tron.svg?branch=master)](https://travis-ci.org/tailuge/bot-o-tron/) [![Coverage Status](https://coveralls.io/repos/github/tailuge/bot-o-tron/badge.svg?branch=master)](https://coveralls.io/github/tailuge/bot-o-tron?branch=master) [![Dependency Status](https://david-dm.org/tailuge/bot-o-tron.svg)](https://david-dm.org/tailuge/bot-o-tron) [![devDependency Status](https://david-dm.org/tailuge/bot-o-tron/dev-status.svg)](https://david-dm.org/tailuge/bot-o-tron#info=devDependencies) [![CodeFactor](https://www.codefactor.io/repository/github/tailuge/bot-o-tron/badge)](https://www.codefactor.io/repository/github/tailuge/bot-o-tron) [![Open in Gitpod](https://img.shields.io/badge/Gitpod-Open%20in%20Gitpod-%230092CF.svg)](https://gitpod.io/#https://github.com/tailuge/bot-o-tron)
 
-Try out [lichess'](https://lichess.org) bot interface https://lichess.org/api#tag/Chess-Bot
+Try out [lichess'](https://lichess.org) bot interface https://lichess.org/api#tag/Bot
 
 ### Setup
 

--- a/src/LichessApi.js
+++ b/src/LichessApi.js
@@ -27,7 +27,7 @@ class LichessApi {
   }
 
   upgrade() {
-    return this.post("api/bot/accounts/upgrade");
+    return this.post("api/bot/account/upgrade");
   }
 
   accountInfo() {

--- a/src/LichessApi.js
+++ b/src/LichessApi.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const oboe = require("oboe");
 /**
- * Programatic interface to the web API of lichess https://lichess.org/api#tag/Chess-Bot
+ * Programatic interface to the web API of lichess https://lichess.org/api#tag/Bot
  *  
  */
 class LichessApi {

--- a/test/TestLichessApi.js
+++ b/test/TestLichessApi.js
@@ -85,7 +85,7 @@ tap.test("declineChallenge", async function(t) {
 });
 
 tap.test("upgrade", async function(t) {
-  assertRequest(t, "post", new RegExp("api/bot/accounts/upgrade"), okResponse);
+  assertRequest(t, "post", new RegExp("api/bot/account/upgrade"), okResponse);
   const response = await api.upgrade();
   t.equal(response.data.ok, true, "response correct");
   t.end();


### PR DESCRIPTION
1. Correct 'Bot Upgrade' API Endpoint:
- Do note that the ‘Bot Upgrade’ API Endpoint was earlier "api/bot/accounts/upgrade" instead of "api/bot/account/upgrade" which has been corrected.

2. Fix broken link
- The link under lichess api was directed to the old bot api url. I’ve changed it to use https://lichess.org/api#tag/Bot instead of https://lichess.org/api#tag/Chess-Bot as the latter redirects to https://lichess.org/api